### PR TITLE
Fix error append_row

### DIFF
--- a/cox/store.py
+++ b/cox/store.py
@@ -413,7 +413,7 @@ class Table():
             nrows = 0
 
         df.index += nrows
-        self._HDFStore.append(self._name, df, table=True)
+        self._HDFStore.append(self._name, df, format='table')
 
         if not self._has_initialized:
              self._initialize_nonempty_table()


### PR DESCRIPTION
**Error:**  When running `store['my_table'].append_row(...)` I was getting the error:

![image](https://user-images.githubusercontent.com/18227298/77846475-f8cb0100-71be-11ea-81a9-67fe1fc391d4.png)

**Possible cause**: I suspect that the error is because you are using an older version of Pandas. In the latest version of Pandas, the documentation shows that the field `table=True` was replaced by `format='table'` ([docs](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.HDFStore.append.html))



All my python packages https://pastebin.com/2dMa9GhT, running python 3.7 on macOS